### PR TITLE
fix: update OllamaClient to use generate instead of chat to fix tool-…

### DIFF
--- a/intelligence-per-watt/src/ipw/clients/ollama.py
+++ b/intelligence-per-watt/src/ipw/clients/ollama.py
@@ -83,6 +83,6 @@ class OllamaClient(InferenceClient):
     ) -> dict[str, Any]:
         payload = dict(params)
         payload["model"] = model
-        payload.setdefault("prompt", prompt)
+        payload["prompt"] = prompt
         payload["stream"] = True
         return payload


### PR DESCRIPTION
This pull request updates the Ollama client integration in `intelligence-per-watt/src/ipw/clients/ollama.py` to use the newer streaming API and payload format. The main changes involve switching from the chat-based API to the generate-based API and updating how prompts and responses are handled.

**Ollama client API migration:**

* Changed the streaming method from `self._client.chat` to `self._client.generate` to use the newer Ollama API for streaming completions.
* Updated the payload construction in `_build_payload` to use the `prompt` field instead of the `messages` field, aligning with the requirements of the `generate` API.
* Modified response handling in `stream_chat_completion` to extract the generated text from the `response` attribute of each chunk instead of from `message.content`.…related issues