### PR TITLE
fix: remove unsupported pip install from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,6 @@ See [Prerequisites](https://hazyresearch.stanford.edu/intelligence-per-watt/gett
 ## Installation
 
 ```bash
-pip install intelligence-per-watt
-```
-
-Or from source:
-
-```bash
 git clone https://github.com/HazyResearch/intelligence-per-watt.git
 cd intelligence-per-watt
 uv venv && source .venv/bin/activate

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,6 @@ hide:
 
 <p class="hero-tagline">Benchmarking Intelligence Efficiency of LM Inference.</p>
 
-<p class="install-command">pip install intelligence-per-watt</p>
-
 [Get Started](getting-started/installation.md){ .md-button .md-button--primary }
 [View on GitHub](https://github.com/HazyResearch/intelligence-per-watt){ .md-button }
 


### PR DESCRIPTION
## Summary
- Remove `pip install intelligence-per-watt` from README.md and docs landing page
- The package is not published to PyPI so this command doesn't work
- From-source installation via `uv pip install -e` remains documented

## Test plan
- [ ] Verify README installation section reads correctly
- [ ] Verify docs site landing page renders without the install command