### PR TITLE
feat: add GDPval dataset + rubric-based scoring + Qwen3.5-9B preset

### DIFF
--- a/intelligence-per-watt/src/ipw/agents/openhands.py
+++ b/intelligence-per-watt/src/ipw/agents/openhands.py
@@ -6,7 +6,9 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Sequence
 
 from ipw.agents.base import BaseAgent
@@ -426,6 +428,20 @@ class OpenHands(BaseAgent):
 
     def set_task_metadata(self, metadata: MutableMapping[str, Any]) -> None:
         self._task_metadata = metadata
+        # GDPval: materialize reference files into the workspace so the agent
+        # can read them via its file tools. Skipped in TerminalBench mode
+        # (handled separately via Docker copy).
+        inputs_dir = metadata.get("gdpval_inputs_dir") if metadata else None
+        if inputs_dir and not metadata.get("session"):
+            try:
+                dest = Path(self._workspace) / "inputs"
+                dest.mkdir(parents=True, exist_ok=True)
+                for src in Path(inputs_dir).iterdir():
+                    target = dest / src.name
+                    if not target.exists():
+                        shutil.copy2(src, target)
+            except Exception:
+                logger.warning("Failed to stage gdpval inputs", exc_info=True)
 
     def set_workspace(self, workspace_path: str) -> None:
         """Set the workspace directory for the next agent run."""

--- a/intelligence-per-watt/src/ipw/agents/terminus.py
+++ b/intelligence-per-watt/src/ipw/agents/terminus.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import io
+import logging
+import tarfile
 import time
-from typing import TYPE_CHECKING, Any, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, MutableMapping, Optional
 
 from ipw.agents.base import BaseAgent
 from ipw.core.registry import AgentRegistry
 from ipw.core.types import AgentRunResult
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ipw.telemetry.events import EventRecorder
@@ -116,6 +122,25 @@ class Terminus(BaseAgent):
             raise RuntimeError("Timeout waiting for tmux installation in container")
 
         return container
+
+    def set_task_metadata(self, metadata: MutableMapping[str, Any]) -> None:
+        """Stage GDPval reference files into ``/workspace/inputs`` if present."""
+        inputs_dir = metadata.get("gdpval_inputs_dir") if metadata else None
+        if not inputs_dir:
+            return
+        try:
+            container = self._get_or_create_container()
+            # tar the inputs dir and stream it into the container
+            buf = io.BytesIO()
+            with tarfile.open(fileobj=buf, mode="w") as tar:
+                src_root = Path(inputs_dir)
+                for src in src_root.iterdir():
+                    tar.add(str(src), arcname=src.name)
+            buf.seek(0)
+            container.exec_run(["mkdir", "-p", "/workspace/inputs"])
+            container.put_archive("/workspace/inputs", buf.getvalue())
+        except Exception:
+            logger.warning("Failed to stage gdpval inputs into container", exc_info=True)
 
     def get_session(self, tmux_session: Any = None) -> Any:
         """Get or create a TmuxSession.

--- a/intelligence-per-watt/src/ipw/cli/model_presets.py
+++ b/intelligence-per-watt/src/ipw/cli/model_presets.py
@@ -96,6 +96,15 @@ MODEL_PRESETS: Dict[str, Dict[str, Any]] = {
             "language_model_only": True,
         },
     },
+    "qwen35-9b": {
+        "model_id": "Qwen/Qwen3.5-9B",
+        "vllm_args": {
+            "tensor_parallel_size": 1,
+            "reasoning_parser": "qwen3",
+            "tool_call_parser": "qwen3_coder",
+            "language_model_only": True,
+        },
+    },
     "qwen35-397b-a17b-fp8": {
         "model_id": "Qwen/Qwen3.5-397B-A17B-FP8",
         "vllm_args": {

--- a/intelligence-per-watt/src/ipw/datasets/__init__.py
+++ b/intelligence-per-watt/src/ipw/datasets/__init__.py
@@ -11,6 +11,7 @@ def ensure_registered() -> None:
     from . import (  # noqa: F401
         frames,
         gaia,
+        gdpval,
         gpqa,
         hle,
         ipw,

--- a/intelligence-per-watt/src/ipw/datasets/gdpval.py
+++ b/intelligence-per-watt/src/ipw/datasets/gdpval.py
@@ -1,0 +1,271 @@
+"""GDPval dataset (openai/gdpval).
+
+Real-world professional tasks across 44 occupations. Each task has:
+- A long-form prompt
+- A set of reference files (Excel/PDF/Word) the agent should read
+- A set of deliverable files the model is expected to produce
+- A machine-readable rubric (rubric_json) for grading
+
+This provider downloads reference files into a per-task cache, augments the
+prompt with on-disk paths, and routes scoring to the ``gdpval`` evaluation
+handler (rubric-based LLM-as-judge).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+
+from huggingface_hub import hf_hub_download
+
+from datasets import load_dataset
+
+from ..clients.base import InferenceClient
+from ..core.registry import ClientRegistry, DatasetRegistry, EvaluationRegistry
+from ..core.types import DatasetRecord
+from .base import DatasetProvider
+
+LOGGER = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = Path.home() / ".cache" / "gdpval"
+
+_PROMPT_TEMPLATE = """You are a domain expert in: {occupation} ({sector}).
+
+Complete the following professional task. Use any reference files provided \
+and produce a high-quality answer that a professional in this role would \
+accept as a deliverable.
+
+{file_section}
+
+## Task
+
+{task_prompt}
+
+When you finish, write your final answer / deliverable as plain text in the \
+last message. If you produced a file (e.g. spreadsheet, document), include \
+its location and a detailed description of its contents so it can be graded.
+"""
+
+
+def _hf_uri_to_repo_path(hf_uri: str) -> Optional[Tuple[str, str]]:
+    """Parse ``hf://datasets/<repo>/<path>`` into ``(repo, path)``.
+
+    Returns ``None`` if the URI isn't a HuggingFace dataset URI.
+    """
+    if not hf_uri or not isinstance(hf_uri, str):
+        return None
+    prefix = "hf://datasets/"
+    if not hf_uri.startswith(prefix):
+        return None
+    remainder = hf_uri[len(prefix):]
+    # repo is the first two path segments: "<org>/<name>"
+    parts = remainder.split("/", 2)
+    if len(parts) < 3:
+        return None
+    repo = f"{parts[0]}/{parts[1]}"
+    file_path = parts[2]
+    return repo, file_path
+
+
+@DatasetRegistry.register("gdpval")
+class GDPvalDataset(DatasetProvider):
+    """OpenAI GDPval dataset (openai/gdpval).
+
+    Loads 220 professional tasks from HuggingFace, downloads associated
+    reference files on demand, and yields one ``DatasetRecord`` per task.
+    Scoring uses the rubric-based ``gdpval`` evaluation handler.
+    """
+
+    dataset_id = "gdpval"
+    dataset_name = "GDPval"
+    evaluation_method = "gdpval"
+
+    _hf_path = "openai/gdpval"
+    _default_split = "train"
+    _default_subset = "default"
+
+    def __init__(
+        self,
+        *,
+        split: Optional[str] = None,
+        subset: Optional[str] = None,
+        max_samples: Optional[int] = None,
+        cache_dir: Optional[str] = None,
+        download_files: bool = True,
+    ) -> None:
+        self._split = split or self._default_split
+        self._subset = subset or self._default_subset
+        self._max_samples = max_samples
+        self._cache_dir = Path(cache_dir) if cache_dir else _DEFAULT_CACHE_DIR
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._download_files = download_files
+        self._records: Tuple[DatasetRecord, ...] = tuple(self._build_records())
+
+    def iter_records(self) -> Iterable[DatasetRecord]:
+        return iter(self._records)
+
+    def size(self) -> int:
+        return len(self._records)
+
+    def verify_requirements(self) -> list[str]:
+        issues: list[str] = []
+        if not (os.getenv("IPW_EVAL_API_KEY") or os.getenv("OPENAI_API_KEY")):
+            issues.append(
+                "Missing evaluation API key. Set IPW_EVAL_API_KEY (preferred) or "
+                "OPENAI_API_KEY — GDPval scoring uses LLM-as-judge over the rubric."
+            )
+        return issues
+
+    def score(
+        self,
+        record: DatasetRecord,
+        response: str,
+        *,
+        eval_client: Optional[InferenceClient] = None,
+    ) -> Tuple[Optional[bool], Dict[str, object]]:
+        handler = self._resolve_handler(eval_client)
+        return handler.evaluate(
+            problem=record.problem,
+            reference=record.answer,
+            model_answer=response,
+            metadata=record.dataset_metadata,
+        )
+
+    def _resolve_handler(self, eval_client: Optional[InferenceClient]):
+        judge_client = eval_client or ClientRegistry.create(
+            self.eval_client or "openai",
+            base_url=self.eval_base_url or "https://api.openai.com/v1",
+            model=self.eval_model or "gpt-5-nano-2025-08-07",
+        )
+        return EvaluationRegistry.create(self.evaluation_method, client=judge_client)
+
+    # ------------------------------------------------------------------
+    # Dataset loading
+    # ------------------------------------------------------------------
+
+    def _build_records(self) -> List[DatasetRecord]:
+        dataset = load_dataset(self._hf_path, name=self._subset, split=self._split)
+
+        rows: Sequence[MutableMapping[str, Any]]
+        if hasattr(dataset, "to_list"):
+            rows = dataset.to_list()
+        else:
+            rows = list(dataset)
+        if self._max_samples is not None:
+            rows = rows[: self._max_samples]
+
+        records: list[DatasetRecord] = []
+        for raw in rows:
+            record = self._convert_row(dict(raw))
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _convert_row(self, raw: MutableMapping[str, Any]) -> Optional[DatasetRecord]:
+        task_id = str(raw.get("task_id") or "").strip()
+        prompt = str(raw.get("prompt") or "").strip()
+        if not task_id or not prompt:
+            return None
+
+        occupation = str(raw.get("occupation") or "").strip() or "Professional"
+        sector = str(raw.get("sector") or "").strip() or "General"
+
+        reference_hf_uris = list(raw.get("reference_file_hf_uris") or [])
+        reference_urls = list(raw.get("reference_file_urls") or [])
+        deliverable_hf_uris = list(raw.get("deliverable_file_hf_uris") or [])
+
+        rubric_json_raw = raw.get("rubric_json") or ""
+        rubric_pretty = raw.get("rubric_pretty") or ""
+
+        # Materialize reference files on disk (downloaded lazily on first use)
+        inputs_dir = self._cache_dir / task_id / "inputs"
+        if self._download_files:
+            local_paths = self._materialize_files(reference_hf_uris, inputs_dir)
+        else:
+            local_paths = []
+
+        # Build a human-readable file listing for the prompt.
+        # Files are copied into the agent's working environment under
+        # ./inputs/ (OpenHands LocalConversation) or /workspace/inputs/
+        # (Terminus Docker) — see ipw/agents/{openhands,terminus}.py.
+        if local_paths:
+            file_lines = "\n".join(f"- {p.name}" for p in local_paths)
+            file_section = (
+                "## Reference files\n\n"
+                "The following files are available in the working directory "
+                "under `inputs/` (or `/workspace/inputs/` if you are in a "
+                "sandboxed shell). Read them with whatever file tools you "
+                "have available.\n\n"
+                f"{file_lines}\n"
+            )
+        elif reference_urls:
+            url_lines = "\n".join(f"- {u}" for u in reference_urls)
+            file_section = (
+                "## Reference files (download from URL)\n\n"
+                f"{url_lines}\n"
+            )
+        else:
+            file_section = ""
+
+        task_prompt = _PROMPT_TEMPLATE.format(
+            occupation=occupation,
+            sector=sector,
+            file_section=file_section,
+            task_prompt=prompt,
+        )
+
+        metadata: dict[str, Any] = {
+            "dataset_name": self.dataset_name,
+            "task_id": task_id,
+            "instance_id": task_id,
+            "occupation": occupation,
+            "sector": sector,
+            "reference_file_hf_uris": reference_hf_uris,
+            "reference_file_urls": reference_urls,
+            "deliverable_file_hf_uris": deliverable_hf_uris,
+            "gdpval_inputs_dir": str(inputs_dir) if local_paths else None,
+            "rubric_pretty": rubric_pretty,
+            "rubric_json": rubric_json_raw,
+        }
+
+        # The "answer" slot is unused for GDPval (no reference answers); we
+        # store rubric_pretty there so it shows up in artifact dumps.
+        return DatasetRecord(
+            problem=task_prompt,
+            answer=rubric_pretty if isinstance(rubric_pretty, str) else "",
+            subject=occupation,
+            dataset_metadata=metadata,
+        )
+
+    def _materialize_files(self, hf_uris: List[str], dest_dir: Path) -> List[Path]:
+        """Download each HF URI into ``dest_dir`` (idempotent, cached)."""
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        local_paths: list[Path] = []
+        for uri in hf_uris:
+            parsed = _hf_uri_to_repo_path(uri)
+            if parsed is None:
+                LOGGER.warning("Skipping non-HF reference URI: %s", uri)
+                continue
+            repo, path_in_repo = parsed
+            try:
+                local = hf_hub_download(
+                    repo_id=repo,
+                    repo_type="dataset",
+                    filename=path_in_repo,
+                    cache_dir=str(self._cache_dir / "_hf_cache"),
+                )
+            except Exception as exc:
+                LOGGER.warning("Failed to download %s: %s", uri, exc)
+                continue
+            # Copy into dest_dir with a flat filename so agents see a clean tree
+            target = dest_dir / Path(path_in_repo).name
+            if not target.exists():
+                shutil.copy2(local, target)
+            local_paths.append(target)
+        return local_paths
+
+
+__all__ = ["GDPvalDataset"]

--- a/intelligence-per-watt/src/ipw/evaluation/__init__.py
+++ b/intelligence-per-watt/src/ipw/evaluation/__init__.py
@@ -1,6 +1,7 @@
 from .base import EvaluationHandler
 from .frames import FRAMESHandler
 from .gaia import GAIAHandler
+from .gdpval import GdpvalHandler
 from .gpqa import GPQAHandler, SuperGPQAHandler
 from .hle import HLEHandler
 from .math500 import Math500Handler
@@ -18,6 +19,7 @@ __all__ = [
     "EvaluationHandler",
     "FRAMESHandler",
     "GAIAHandler",
+    "GdpvalHandler",
     "GPQAHandler",
     "SuperGPQAHandler",
     "HLEHandler",

--- a/intelligence-per-watt/src/ipw/evaluation/gdpval.py
+++ b/intelligence-per-watt/src/ipw/evaluation/gdpval.py
@@ -1,0 +1,200 @@
+"""GDPval evaluation: rubric-based LLM-as-judge.
+
+GDPval tasks have no reference answers — each task ships a ``rubric_json``
+listing criteria with point values. We ask the judge model to score the
+candidate answer against each criterion, then aggregate:
+
+- A criterion is satisfied iff the judge returns "yes".
+- Score = (achieved points) / (max points).
+- ``is_correct`` is True iff every ``required: true`` criterion is satisfied
+  AND the achieved score is at least the configured pass threshold (default
+  0.5).
+- If the rubric is malformed or no criteria are present, returns ``None``
+  (unscorable).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..core.registry import EvaluationRegistry
+from .base import EvaluationHandler
+
+LOGGER = logging.getLogger(__name__)
+
+_PASS_THRESHOLD = 0.5
+
+_JUDGE_PROMPT = """You are grading a candidate response against a single rubric criterion.
+
+## Task given to the candidate
+{problem}
+
+## Candidate response
+{response}
+
+## Rubric criterion
+{criterion}
+
+Does the candidate response satisfy this criterion?
+
+Reply with exactly one line in this format:
+verdict: <yes or no>
+reason: <one short sentence>
+"""
+
+
+def _parse_rubric(raw: Any) -> List[Dict[str, Any]]:
+    """Return the list of rubric items from a rubric_json blob."""
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        items = raw
+    elif isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            items = parsed
+        elif isinstance(parsed, dict):
+            # Some rubrics wrap the list under a key
+            items = (
+                parsed.get("rubric")
+                or parsed.get("criteria")
+                or parsed.get("items")
+                or []
+            )
+        else:
+            return []
+    else:
+        return []
+
+    cleaned: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict) and item.get("criterion"):
+            cleaned.append(item)
+    return cleaned
+
+
+def _judge_verdict(raw: str) -> bool:
+    """Return True iff the judge said 'verdict: yes'."""
+    if not raw:
+        return False
+    m = re.search(r"verdict\s*:\s*(yes|no)", raw, re.IGNORECASE)
+    if m:
+        return m.group(1).lower() == "yes"
+    # Fallback: any standalone yes/no token in the first line
+    first_line = raw.strip().splitlines()[0] if raw.strip() else ""
+    return bool(re.search(r"\byes\b", first_line, re.IGNORECASE))
+
+
+@EvaluationRegistry.register("gdpval")
+class GdpvalHandler(EvaluationHandler):
+    """Rubric-based LLM-as-judge grading for GDPval tasks."""
+
+    evaluation_method = "gdpval"
+
+    def evaluate(
+        self,
+        *,
+        problem: str,
+        reference: str,
+        model_answer: str,
+        metadata: Dict[str, object],
+    ) -> Tuple[Optional[bool], Dict[str, object]]:
+        if not model_answer or not model_answer.strip():
+            return False, {"reason": "empty_response"}
+
+        rubric_raw = metadata.get("rubric_json")
+        rubric = _parse_rubric(rubric_raw)
+        if not rubric:
+            return None, {"reason": "no_rubric"}
+
+        if not hasattr(self._client, "chat"):
+            return None, {"reason": "no_llm_client_for_judging"}
+
+        per_criterion: list[dict[str, Any]] = []
+        achieved_points = 0.0
+        max_points = 0.0
+        required_failures = 0
+
+        for idx, item in enumerate(rubric):
+            criterion_text = str(item.get("criterion") or "").strip()
+            if not criterion_text:
+                continue
+
+            try:
+                points = float(item.get("score", 1.0))
+            except (TypeError, ValueError):
+                points = 1.0
+            required = bool(item.get("required", False))
+            rubric_item_id = item.get("rubric_item_id", f"item_{idx}")
+
+            max_points += points
+
+            prompt = _JUDGE_PROMPT.format(
+                problem=problem[:4000],  # keep judge prompt bounded
+                response=model_answer[:8000],
+                criterion=criterion_text,
+            )
+            try:
+                raw = self._client.chat(
+                    system_prompt="",
+                    user_prompt=prompt,
+                    temperature=0.0,
+                    max_output_tokens=512,
+                )
+            except Exception as exc:
+                LOGGER.warning(
+                    "Rubric judge failed for item %s: %s", rubric_item_id, exc
+                )
+                per_criterion.append(
+                    {
+                        "rubric_item_id": rubric_item_id,
+                        "criterion": criterion_text,
+                        "points": points,
+                        "required": required,
+                        "satisfied": False,
+                        "error": str(exc),
+                    }
+                )
+                if required:
+                    required_failures += 1
+                continue
+
+            satisfied = _judge_verdict(raw)
+            if satisfied:
+                achieved_points += points
+            elif required:
+                required_failures += 1
+
+            per_criterion.append(
+                {
+                    "rubric_item_id": rubric_item_id,
+                    "criterion": criterion_text,
+                    "points": points,
+                    "required": required,
+                    "satisfied": satisfied,
+                    "judge_output": raw[:500],
+                }
+            )
+
+        score = achieved_points / max_points if max_points > 0 else 0.0
+        is_correct = required_failures == 0 and score >= _PASS_THRESHOLD
+
+        return is_correct, {
+            "match_type": "rubric_llm_judge",
+            "score": score,
+            "achieved_points": achieved_points,
+            "max_points": max_points,
+            "required_failures": required_failures,
+            "num_criteria": len(per_criterion),
+            "per_criterion": per_criterion,
+            "pass_threshold": _PASS_THRESHOLD,
+        }
+
+
+__all__ = ["GdpvalHandler"]

--- a/intelligence-per-watt/src/ipw/tests/datasets/test_gdpval.py
+++ b/intelligence-per-watt/src/ipw/tests/datasets/test_gdpval.py
@@ -1,0 +1,149 @@
+"""Tests for datasets/gdpval.py — GDPvalDataset."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from ipw.core.types import DatasetRecord
+
+
+def _sample_row(task_id: str = "t1", with_rubric: bool = True) -> dict:
+    return {
+        "task_id": task_id,
+        "sector": "Professional Services",
+        "occupation": "Accountant",
+        "prompt": "Prepare a Q4 tax summary based on the attached statements.",
+        "reference_files": [],
+        "reference_file_urls": [
+            "https://example.com/q4_statements.pdf",
+        ],
+        "reference_file_hf_uris": [
+            "hf://datasets/openai/gdpval/files/q4_statements.pdf",
+        ],
+        "deliverable_files": [],
+        "deliverable_file_urls": [],
+        "deliverable_file_hf_uris": [],
+        "rubric_pretty": "Tax summary rubric",
+        "rubric_json": json.dumps(
+            [
+                {
+                    "rubric_item_id": "r1",
+                    "criterion": "Includes total revenue.",
+                    "score": 2,
+                    "required": True,
+                },
+                {
+                    "rubric_item_id": "r2",
+                    "criterion": "Includes deductions.",
+                    "score": 1,
+                    "required": False,
+                },
+            ]
+        ) if with_rubric else "",
+    }
+
+
+class TestGDPvalDataset:
+    @patch("ipw.datasets.gdpval.hf_hub_download")
+    @patch("ipw.datasets.gdpval.load_dataset")
+    def test_iter_records_yields_dataset_records(
+        self,
+        mock_load_dataset: MagicMock,
+        mock_hf_download: MagicMock,
+        tmp_path,
+    ) -> None:
+        from ipw.datasets.gdpval import GDPvalDataset
+
+        mock_dataset = MagicMock()
+        mock_dataset.to_list.return_value = [_sample_row("t1"), _sample_row("t2")]
+        mock_load_dataset.return_value = mock_dataset
+
+        # Pretend the HF download returns a stub file we can copy
+        stub = tmp_path / "_stub.pdf"
+        stub.write_bytes(b"stub")
+        mock_hf_download.return_value = str(stub)
+
+        dataset = GDPvalDataset(cache_dir=str(tmp_path / "cache"))
+        records = list(dataset.iter_records())
+
+        assert len(records) == 2
+        assert all(isinstance(r, DatasetRecord) for r in records)
+        assert "Q4 tax summary" in records[0].problem
+        assert records[0].subject == "Accountant"
+        # Each task's inputs dir should be unique
+        d1 = records[0].dataset_metadata["gdpval_inputs_dir"]
+        d2 = records[1].dataset_metadata["gdpval_inputs_dir"]
+        assert d1 != d2
+
+    @patch("ipw.datasets.gdpval.hf_hub_download")
+    @patch("ipw.datasets.gdpval.load_dataset")
+    def test_max_samples_limits_records(
+        self,
+        mock_load_dataset: MagicMock,
+        mock_hf_download: MagicMock,
+        tmp_path,
+    ) -> None:
+        from ipw.datasets.gdpval import GDPvalDataset
+
+        mock_dataset = MagicMock()
+        mock_dataset.to_list.return_value = [_sample_row(f"t{i}") for i in range(10)]
+        mock_load_dataset.return_value = mock_dataset
+        stub = tmp_path / "_stub.pdf"
+        stub.write_bytes(b"x")
+        mock_hf_download.return_value = str(stub)
+
+        dataset = GDPvalDataset(
+            cache_dir=str(tmp_path / "cache"),
+            max_samples=3,
+        )
+        assert dataset.size() == 3
+
+    @patch("ipw.datasets.gdpval.hf_hub_download")
+    @patch("ipw.datasets.gdpval.load_dataset")
+    def test_metadata_carries_rubric_and_occupation(
+        self,
+        mock_load_dataset: MagicMock,
+        mock_hf_download: MagicMock,
+        tmp_path,
+    ) -> None:
+        from ipw.datasets.gdpval import GDPvalDataset
+
+        mock_dataset = MagicMock()
+        mock_dataset.to_list.return_value = [_sample_row("t1")]
+        mock_load_dataset.return_value = mock_dataset
+        stub = tmp_path / "_stub.pdf"
+        stub.write_bytes(b"x")
+        mock_hf_download.return_value = str(stub)
+
+        dataset = GDPvalDataset(cache_dir=str(tmp_path / "cache"))
+        record = list(dataset.iter_records())[0]
+        meta = record.dataset_metadata
+        assert meta["dataset_name"] == "GDPval"
+        assert meta["task_id"] == "t1"
+        assert meta["occupation"] == "Accountant"
+        assert meta["sector"] == "Professional Services"
+        assert meta["rubric_json"]  # not empty
+
+    @patch("ipw.datasets.gdpval.hf_hub_download")
+    @patch("ipw.datasets.gdpval.load_dataset")
+    def test_skip_download_when_disabled(
+        self,
+        mock_load_dataset: MagicMock,
+        mock_hf_download: MagicMock,
+        tmp_path,
+    ) -> None:
+        from ipw.datasets.gdpval import GDPvalDataset
+
+        mock_dataset = MagicMock()
+        mock_dataset.to_list.return_value = [_sample_row("t1")]
+        mock_load_dataset.return_value = mock_dataset
+
+        dataset = GDPvalDataset(
+            cache_dir=str(tmp_path / "cache"),
+            download_files=False,
+        )
+        records = list(dataset.iter_records())
+        mock_hf_download.assert_not_called()
+        # Falls back to URLs in the prompt
+        assert "example.com" in records[0].problem

--- a/intelligence-per-watt/src/ipw/tests/evaluation/test_gdpval_eval.py
+++ b/intelligence-per-watt/src/ipw/tests/evaluation/test_gdpval_eval.py
@@ -1,0 +1,126 @@
+"""Tests for evaluation/gdpval.py — GdpvalHandler (rubric LLM-as-judge)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+
+def _rubric(items):
+    return json.dumps(items)
+
+
+class TestGdpvalHandler:
+    def test_returns_none_when_no_rubric(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        handler = GdpvalHandler(client=MagicMock())
+        is_correct, meta = handler.evaluate(
+            problem="task", reference="", model_answer="answer", metadata={}
+        )
+        assert is_correct is None
+        assert meta["reason"] == "no_rubric"
+
+    def test_empty_response_is_false(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        handler = GdpvalHandler(client=MagicMock())
+        is_correct, meta = handler.evaluate(
+            problem="task",
+            reference="",
+            model_answer="",
+            metadata={"rubric_json": _rubric([{"criterion": "x", "score": 1}])},
+        )
+        assert is_correct is False
+        assert meta["reason"] == "empty_response"
+
+    def test_all_pass_required_criteria(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        client = MagicMock()
+        client.chat.return_value = "verdict: yes\nreason: looks good"
+        handler = GdpvalHandler(client=client)
+
+        rubric = [
+            {"rubric_item_id": "a", "criterion": "Has totals", "score": 2, "required": True},
+            {"rubric_item_id": "b", "criterion": "Has detail", "score": 1, "required": False},
+        ]
+        is_correct, meta = handler.evaluate(
+            problem="task",
+            reference="",
+            model_answer="my answer with totals and detail",
+            metadata={"rubric_json": _rubric(rubric)},
+        )
+        assert is_correct is True
+        assert meta["match_type"] == "rubric_llm_judge"
+        assert meta["achieved_points"] == 3.0
+        assert meta["max_points"] == 3.0
+        assert meta["required_failures"] == 0
+
+    def test_required_failure_fails_task(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        client = MagicMock()
+        # First criterion is required and judge says no
+        client.chat.side_effect = [
+            "verdict: no\nreason: missing totals",
+            "verdict: yes\nreason: has detail",
+        ]
+        handler = GdpvalHandler(client=client)
+
+        rubric = [
+            {"rubric_item_id": "a", "criterion": "Has totals", "score": 2, "required": True},
+            {"rubric_item_id": "b", "criterion": "Has detail", "score": 1, "required": False},
+        ]
+        is_correct, meta = handler.evaluate(
+            problem="task",
+            reference="",
+            model_answer="answer",
+            metadata={"rubric_json": _rubric(rubric)},
+        )
+        assert is_correct is False
+        assert meta["required_failures"] == 1
+        assert meta["achieved_points"] == 1.0
+
+    def test_score_below_threshold_fails(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        client = MagicMock()
+        # Two of five criteria pass; no required → score 2/5 = 0.4 < 0.5
+        client.chat.side_effect = [
+            "verdict: yes",
+            "verdict: yes",
+            "verdict: no",
+            "verdict: no",
+            "verdict: no",
+        ]
+        handler = GdpvalHandler(client=client)
+        rubric = [
+            {"criterion": f"c{i}", "score": 1, "required": False} for i in range(5)
+        ]
+        is_correct, meta = handler.evaluate(
+            problem="task",
+            reference="",
+            model_answer="answer",
+            metadata={"rubric_json": _rubric(rubric)},
+        )
+        assert is_correct is False
+        assert meta["score"] == 0.4
+
+    def test_handles_malformed_judge_output(self) -> None:
+        from ipw.evaluation.gdpval import GdpvalHandler
+
+        client = MagicMock()
+        client.chat.return_value = "garbled response with no verdict line"
+        handler = GdpvalHandler(client=client)
+
+        rubric = [{"criterion": "c", "score": 1, "required": False}]
+        is_correct, meta = handler.evaluate(
+            problem="task",
+            reference="",
+            model_answer="answer",
+            metadata={"rubric_json": _rubric(rubric)},
+        )
+        # Malformed → treat as not satisfied; score 0 → False
+        assert is_correct is False
+        assert meta["achieved_points"] == 0.0


### PR DESCRIPTION
Wires openai/gdpval into the agentic-run pipeline with file staging for Terminus (Docker) and OpenHands (LocalConversation), rubric LLM-as-judge scoring against rubric_json, and a qwen35-9b model preset.