### PR TITLE
Fix CI lint + OpenHands test broken by PR #33 merge

### DIFF
--- a/intelligence-per-watt/src/ipw/evaluation/gdpval.py
+++ b/intelligence-per-watt/src/ipw/evaluation/gdpval.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import os
 import re
 import subprocess
 import tempfile
@@ -45,14 +44,15 @@ def _describe_image_with_vision(path: Path, client) -> str:
     O(n_criteria).
     """
     if not hasattr(client, "_chat_completion"):
-        return f"<vision unavailable: client lacks _chat_completion>"
+        return "<vision unavailable: client lacks _chat_completion>"
     try:
         with path.open("rb") as f:
             b64 = base64.b64encode(f.read()).decode("ascii")
     except Exception as exc:
         return f"<image read error: {exc}>"
     suf = path.suffix.lower().lstrip(".")
-    if suf == "jpg": suf = "jpeg"
+    if suf == "jpg":
+        suf = "jpeg"
     data_url = f"data:image/{suf};base64,{b64}"
     messages = [
         {"role": "system", "content": "You are a careful visual describer."},

--- a/intelligence-per-watt/src/ipw/execution/agentic_runner.py
+++ b/intelligence-per-watt/src/ipw/execution/agentic_runner.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Optional
 from tqdm.auto import tqdm
 
 from ..agents.base import BaseAgent, ToolUsingAgent
-from ..core.types import AgentRunResult, DatasetRecord
+from ..core.types import DatasetRecord
 from ..datasets.base import DatasetProvider
 from ..execution.telemetry_session import TelemetrySample, TelemetrySession
 from ..execution.trace import QueryTrace, TurnTrace

--- a/intelligence-per-watt/src/ipw/execution/nvidia_smi_telemetry.py
+++ b/intelligence-per-watt/src/ipw/execution/nvidia_smi_telemetry.py
@@ -91,7 +91,6 @@ class NvidiaSmiTelemetrySession(AbstractContextManager["NvidiaSmiTelemetrySessio
 
         total_power = sum(current_power.values())
         total_energy = sum(self._energy_joules.get(gpu_id, 0.0) for gpu_id in self._gpu_ids)
-        first = gpu_samples[0]
         memory_used = _sum_optional(sample.memory_used_mb for sample in gpu_samples)
         memory_total = _sum_optional(sample.memory_total_mb for sample in gpu_samples)
         utilization = _mean_optional(sample.utilization_pct for sample in gpu_samples)

--- a/intelligence-per-watt/src/ipw/tests/agents/test_openhands_integration.py
+++ b/intelligence-per-watt/src/ipw/tests/agents/test_openhands_integration.py
@@ -81,7 +81,11 @@ class TestOpenHandsIntegration:
         model = MagicMock()
         agent = OpenHands(model=model)
         assert agent.model is model
-        _mock_openhands["Agent"].assert_called_once()
+        # Agent construction is deferred to per-run (_create_conversation) so
+        # the per-task workspace is bound freshly; __init__ only captures the
+        # class reference and the kwargs.
+        assert agent._Agent is _mock_openhands["Agent"]
+        _mock_openhands["Agent"].assert_not_called()
 
     def test_run_returns_agent_run_result(self, _mock_openhands: dict) -> None:
         from ipw.agents.openhands import OpenHands


### PR DESCRIPTION
## Summary

The merge of PR #33 broke CI on `main`. Both the `lint` and `test` jobs of `ci.yml` have been failing since [run 27452203203](https://github.com/HazyResearch/intelligence-per-watt/actions/runs/27452203203). This PR fixes all of it.

**Lint (ruff) — 5 errors:**
- `gdpval.py:21` (F401) — drop unused `import os`
- `gdpval.py:48` (F541) — drop extraneous `f` prefix on a literal string
- `gdpval.py:55` (E701) — split a multi-statement `if suf == "jpg": suf = "jpeg"` line
- `agentic_runner.py:23` (F401) — drop unused `AgentRunResult` import (only appears in comments)
- `nvidia_smi_telemetry.py:94` (F841) — drop unused `first = gpu_samples[0]`

**Test — `test_initializes_with_model`:**
PR #33 intentionally deferred `Agent(...)` construction from `__init__` to `_create_conversation()` so each task gets a fresh workspace (see comment in `openhands.py:733-741` about TerminalExecutor state leakage). The test wasn't updated alongside the refactor. Updated the assertion to verify the class reference is captured (`agent._Agent is Agent`) and not yet called.

## Test plan

Verified locally on Python 3.13.5 against all three CI workflows:
- [x] `ci.yml` lint: `ruff check src/ src/ipw/tests/` → `All checks passed!`
- [x] `ci.yml` test: `pytest -m "not integration"` → **1025 passed, 15 skipped, 49 deselected** (was 1 failed, 1027 passed)
- [x] `core-infra-regression.yml`: `pytest src/ipw/tests/{execution,telemetry,tools} -m "not integration and not stress"` → **390 passed, 13 skipped**
- [x] `docs.yml`: `mkdocs build` → built cleanly
- [ ] Confirm green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)