### PR TITLE
patch-openhands-forgecode-react-dspy-rlm-terminus-terminus-tb

### DIFF
--- a/intelligence-per-watt/src/ipw/agents/dspy_rlm.py
+++ b/intelligence-per-watt/src/ipw/agents/dspy_rlm.py
@@ -17,6 +17,30 @@ class DSPyRLM(OpenAICompatibleHarness):
     loop shape while using IPW MCP tools and the existing trace event contract.
     """
 
+    def _pre_tool_observation(
+        self,
+        *,
+        tool_name: str,
+        tool_input: str,
+        turn_index: int,
+        tools_attempted: int,
+    ) -> Optional[str]:
+        return None
+
+    def _post_tool_observation(
+        self,
+        observation: str,
+        *,
+        tool_name: str,
+        tool_input: str,
+        turn_index: int,
+        tools_attempted: int,
+    ) -> str:
+        return observation
+
+    def _turn_limit_final_prompt(self) -> Optional[str]:
+        return None
+
     def run(self, input: str, **kwargs: Any) -> AgentRunResult:
         tool_names = ", ".join(sorted(self.mcp_tools)) or "none"
         system = (
@@ -78,21 +102,56 @@ class DSPyRLM(OpenAICompatibleHarness):
 
             tools_attempted += 1
             tools_used.append(tool_name)
-            self._record_event("tool_call_start", tool=tool_name)
-            try:
-                if tool_name in {"bash", "shell"} and self._terminal_session() is not None:
-                    observation = self._execute_terminal_session_command(tool_input)
-                else:
-                    tool_result = self.mcp_tools[tool_name].execute(tool_input)
-                    observation = getattr(tool_result, "content", str(tool_result))
-                tools_succeeded += 1
-            except Exception as exc:
-                observation = f"Tool error: {exc}"
-            finally:
-                self._record_event("tool_call_end", tool=tool_name)
+            observation = self._pre_tool_observation(
+                tool_name=tool_name,
+                tool_input=tool_input,
+                turn_index=_turn,
+                tools_attempted=tools_attempted,
+            )
+            if observation is None:
+                self._record_event("tool_call_start", tool=tool_name)
+                try:
+                    if tool_name in {"bash", "shell"} and self._terminal_session() is not None:
+                        observation = self._execute_terminal_session_command(tool_input)
+                    else:
+                        tool_result = self.mcp_tools[tool_name].execute(tool_input)
+                        observation = getattr(tool_result, "content", str(tool_result))
+                    tools_succeeded += 1
+                except Exception as exc:
+                    observation = f"Tool error: {exc}"
+                finally:
+                    self._record_event("tool_call_end", tool=tool_name)
+            observation = self._post_tool_observation(
+                observation,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                turn_index=_turn,
+                tools_attempted=tools_attempted,
+            )
 
             messages.append({"role": "assistant", "content": last_content})
             messages.append({"role": "user", "content": f"Observation: {observation}"})
+
+        if final_answer is None:
+            final_prompt = self._turn_limit_final_prompt()
+            if final_prompt:
+                messages.append({"role": "user", "content": final_prompt})
+                result = self._chat(messages)
+                if result.input_tokens is None or result.output_tokens is None:
+                    missing_usage_responses += 1
+                else:
+                    total_input += result.input_tokens
+                    total_output += result.output_tokens
+                if result.cost_usd is None:
+                    missing_cost = True
+                else:
+                    total_cost += result.cost_usd
+                token_sources.append(result.token_source)
+                last_content = result.content
+                final_answer = self._extract_final(last_content)
+                if final_answer is None:
+                    final_answer = last_content
+                messages.append({"role": "assistant", "content": last_content})
 
         token_source = "missing"
         if token_sources:

--- a/intelligence-per-watt/src/ipw/agents/forgecode.py
+++ b/intelligence-per-watt/src/ipw/agents/forgecode.py
@@ -2,12 +2,74 @@
 
 from __future__ import annotations
 
+import re
+import subprocess
 from pathlib import Path
 from typing import Any, Optional
 
 from ipw.agents.dspy_rlm import DSPyRLM
 from ipw.core.registry import AgentRegistry
 from ipw.core.types import AgentRunResult
+
+FORGECODE_DEFAULT_INSTRUCTIONS = """You are a coding agent. Solve the task with minimal, correct changes.
+For repository repair tasks, edit files in the provided workspace and return a unified diff.
+For programming contest tasks, return complete Python code only.
+
+Repository repair pacing:
+- Inspect only the files needed to identify the fix.
+- Do not spend the whole run reading files; after one or two inspection commands, make the smallest plausible edit.
+- After repeated read-only inspections with an empty git diff, read-only commands will be rejected until you edit the workspace.
+- Before finishing, run a targeted check or `git diff --check` when practical.
+- If time or turns are nearly exhausted, prioritize leaving a concrete workspace edit and returning the current diff.
+
+Tool-call contract:
+- Emit exactly one tool call per response when using tools.
+- Put Action: and Action Input: on separate lines.
+- Do not include chat-template markers such as <|tool_call|> or <|channel|>.
+- Do not emit Final: until the patch or answer is ready.
+
+Valid tool-call examples:
+
+Action: bash
+Action Input: grep -R "def target_function" -n .
+
+Action: file_read
+Action Input: src/package/module.py
+
+Action: file_write
+Action Input: {"path": "src/package/module.py", "content": "replacement file contents"}
+
+When finished with a repository repair, respond exactly like:
+Final:
+```diff
+diff --git a/src/package/module.py b/src/package/module.py
+--- a/src/package/module.py
++++ b/src/package/module.py
+@@ -1,2 +1,2 @@
+-old line
++new line
+```
+"""
+
+
+_READ_ONLY_INSPECTION_LIMIT = 3
+_READ_ONLY_BASH_RE = re.compile(
+    r"^(?:"
+    r"cat|"
+    r"grep\b|"
+    r"rg\b|"
+    r"find\b|"
+    r"ls\b|"
+    r"head\b|"
+    r"tail\b|"
+    r"sed\s+-n\b|"
+    r"git\s+(?:diff|grep|log|show|status)\b"
+    r")"
+)
+
+
+def _strip_leading_cd(command: str) -> str:
+    return re.sub(r"^\s*cd\s+\S+\s*&&\s*", "", command.strip())
 
 
 @AgentRegistry.register("forgecode")
@@ -22,17 +84,96 @@ class ForgeCode(DSPyRLM):
         super().__init__(
             *args,
             instructions=instructions
-            or (
-                "You are a coding agent. Solve the task with minimal, correct changes. "
-                "For repository repair tasks, return a unified diff. For programming "
-                "contest tasks, return complete Python code only."
-            ),
+            or FORGECODE_DEFAULT_INSTRUCTIONS,
             **kwargs,
         )
         self._workspace: Optional[Path] = None
 
     def set_workspace(self, workspace_path: str) -> None:
         self._workspace = Path(workspace_path)
+
+    def _workspace_is_git_repo(self) -> bool:
+        return self._workspace is not None and (self._workspace / ".git").exists()
+
+    def _workspace_has_diff(self) -> bool:
+        if not self._workspace_is_git_repo():
+            return False
+        completed = subprocess.run(
+            ["git", "diff", "--quiet"],
+            cwd=self._workspace,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return completed.returncode == 1
+
+    def _workspace_diff(self) -> str:
+        if not self._workspace_is_git_repo():
+            return ""
+        completed = subprocess.run(
+            ["git", "diff", "--binary"],
+            cwd=self._workspace,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+        return completed.stdout if completed.returncode == 0 else ""
+
+    def _is_read_only_inspection(self, tool_name: str, tool_input: str) -> bool:
+        normalized_tool = tool_name.lower().strip()
+        if normalized_tool == "file_read":
+            return True
+        if normalized_tool not in {"bash", "shell"}:
+            return False
+        command = _strip_leading_cd(str(tool_input))
+        return bool(_READ_ONLY_BASH_RE.match(command))
+
+    def _pre_tool_observation(
+        self,
+        *,
+        tool_name: str,
+        tool_input: str,
+        turn_index: int,
+        tools_attempted: int,
+    ) -> Optional[str]:
+        if (
+            not self._workspace_is_git_repo()
+            or tools_attempted <= _READ_ONLY_INSPECTION_LIMIT
+            or self._workspace_has_diff()
+            or not self._is_read_only_inspection(tool_name, tool_input)
+        ):
+            return None
+        return (
+            "Read-only inspection budget exhausted and git diff is still empty. "
+            "Your next response must modify the workspace with a minimal source edit "
+            "using bash, shell, or file_write. Do not inspect another file until a "
+            "workspace diff exists."
+        )
+
+    def _turn_limit_final_prompt(self) -> Optional[str]:
+        diff = self._workspace_diff()
+        if diff.strip():
+            return (
+                "Tool budget exhausted. Do not call another tool. Return exactly "
+                "the current workspace change as a Final fenced unified diff:\n"
+                "Final:\n```diff\n"
+                f"{diff[-12000:]}\n"
+                "```"
+            )
+        return (
+            "Tool budget exhausted and git diff is still empty. Do not call another "
+            "tool. Based on the issue and observations already shown, return your "
+            "best minimal unified diff patch attempt now. Respond exactly as:\n"
+            "Final:\n```diff\n"
+            "diff --git a/path b/path\n"
+            "--- a/path\n"
+            "+++ b/path\n"
+            "@@ ...\n"
+            "-old\n"
+            "+new\n"
+            "```"
+        )
 
     def run(self, input: str, **kwargs: Any) -> AgentRunResult:
         if self._workspace is not None:

--- a/intelligence-per-watt/src/ipw/agents/mcp/vllm_server.py
+++ b/intelligence-per-watt/src/ipw/agents/mcp/vllm_server.py
@@ -21,6 +21,19 @@ _retry_warn_count = 0
 _REQUEST_TIMEOUT_SECONDS = 240.0
 
 
+def _parse_vllm_context_budget_error(text: str) -> tuple[int, int] | None:
+    """Return (context_limit, actual_input_tokens) from vLLM validation text."""
+    lowered = text.lower()
+    limit_match = re.search(r"maximum context length is\s+(\d+)", lowered)
+    input_match = (
+        re.search(r"your request has\s+(\d+)\s+input", lowered)
+        or re.search(r"\((\d+)\s+in the messages?", lowered)
+    )
+    if not limit_match or not input_match:
+        return None
+    return int(limit_match.group(1)), int(input_match.group(1))
+
+
 class VLLMMCPServer(BaseMCPServer):
     """MCP server for vLLM-served models.
 
@@ -227,16 +240,11 @@ class VLLMMCPServer(BaseMCPServer):
             error_text_lower = error_text.lower()
 
             if e.response.status_code == 400 and ("max_tokens" in error_text_lower or "max_completion_tokens" in error_text_lower) and "too large" in error_text_lower:
-                match = re.search(r"maximum context length is (\d+)", error_text_lower)
-                input_match = re.search(r"your request has (\d+) input", error_text_lower)
+                parsed_budget = _parse_vllm_context_budget_error(error_text)
 
-                if match:
-                    validation_limit = int(match.group(1))
-                    actual_input_tokens = int(input_match.group(1)) if input_match else None
-
-                    if actual_input_tokens is None:
-                        raise
-                    capped_max_tokens = max(1, int(validation_limit - actual_input_tokens - 100))
+                if parsed_budget is not None:
+                    validation_limit, actual_input_tokens = parsed_budget
+                    capped_max_tokens = max(1, int(validation_limit - actual_input_tokens - 1))
 
                     if capped_max_tokens < max_tokens and capped_max_tokens > 0:
                         _retry_warn_count += 1

--- a/intelligence-per-watt/src/ipw/agents/openai_compat.py
+++ b/intelligence-per-watt/src/ipw/agents/openai_compat.py
@@ -70,6 +70,19 @@ def _extract_openai_content(data: dict[str, Any]) -> str:
     return str(content or "")
 
 
+def _parse_vllm_context_budget_error(text: str) -> tuple[int, int] | None:
+    """Return (context_limit, actual_input_tokens) from vLLM validation text."""
+    lowered = text.lower()
+    limit_match = re.search(r"maximum context length is\s+(\d+)", lowered)
+    input_match = (
+        re.search(r"your request has\s+(\d+)\s+input", lowered)
+        or re.search(r"\((\d+)\s+in the messages?", lowered)
+    )
+    if not limit_match or not input_match:
+        return None
+    return int(limit_match.group(1)), int(input_match.group(1))
+
+
 class OpenAICompatibleHarness(BaseAgent):
     """Base class for lightweight text/tool harnesses."""
 
@@ -213,11 +226,19 @@ class OpenAICompatibleHarness(BaseAgent):
             or "maximum context length" not in text
         ):
             return response
-        max_tokens = int(payload.get("max_tokens") or 0)
-        if max_tokens <= 1024:
+        token_key = "max_tokens" if "max_tokens" in payload else "max_completion_tokens"
+        max_tokens = int(payload.get(token_key) or 0)
+        if max_tokens <= 1:
+            return response
+        parsed_budget = _parse_vllm_context_budget_error(response.text)
+        if parsed_budget is None:
+            return response
+        context_limit, actual_input_tokens = parsed_budget
+        retry_max_tokens = max(1, context_limit - actual_input_tokens - 1)
+        if retry_max_tokens >= max_tokens:
             return response
         retry_payload = dict(payload)
-        retry_payload["max_tokens"] = max(1024, max_tokens // 2)
+        retry_payload[token_key] = retry_max_tokens
         return requests.post(
             f"{base_url}/chat/completions",
             headers=headers,

--- a/intelligence-per-watt/src/ipw/agents/openhands.py
+++ b/intelligence-per-watt/src/ipw/agents/openhands.py
@@ -26,6 +26,24 @@ logger = logging.getLogger(__name__)
 _docker_host_ip: str | None = None
 
 
+class _IPWTurnLimitReached(RuntimeError):
+    """Raised internally when a capped repair run reaches its LLM-call budget."""
+
+
+def _is_turn_limit_exception(exc: BaseException) -> bool:
+    if isinstance(exc, _IPWTurnLimitReached):
+        return True
+    if "max_turns reached" in str(exc):
+        return True
+    cause = getattr(exc, "__cause__", None)
+    context = getattr(exc, "__context__", None)
+    return any(
+        isinstance(inner, _IPWTurnLimitReached)
+        or (inner is not None and "max_turns reached" in str(inner))
+        for inner in (cause, context)
+    )
+
+
 def _usage_counts(model: Any) -> tuple[int | None, int | None, float | None]:
     """Return accumulated prompt/output tokens and cost from an OpenHands LLM."""
     input_tokens: int | None = None
@@ -120,13 +138,33 @@ def _get_mcp_tool_types() -> tuple[type, type, type, type]:
 def _instrument_openhands_llm(
     model: Any,
     recorder: Optional["EventRecorder"],
+    max_lm_calls: int | None = None,
 ) -> Any:
     """Record every OpenHands LLM call while preserving the LLM instance type."""
-    if recorder is None or getattr(model, "_ipw_instrumented", False) is True:
+    if max_lm_calls is not None:
+        object.__setattr__(model, "_ipw_max_lm_calls", max(1, int(max_lm_calls)))
+        object.__setattr__(model, "_ipw_lm_call_count", 0)
+    if recorder is None and max_lm_calls is None:
+        return model
+    if getattr(model, "_ipw_instrumented", False) is True:
         return model
 
     def _record_event(event_type: str, **metadata: Any) -> None:
+        if recorder is None:
+            return
         recorder.record(event_type, **metadata)
+
+    def _check_turn_limit() -> None:
+        limit = getattr(model, "_ipw_max_lm_calls", None)
+        if limit is None:
+            return
+        current = int(getattr(model, "_ipw_lm_call_count", 0) or 0)
+        if current >= int(limit):
+            raise _IPWTurnLimitReached(f"max_turns reached: {current}/{limit}")
+
+    def _mark_lm_call() -> None:
+        current = int(getattr(model, "_ipw_lm_call_count", 0) or 0)
+        object.__setattr__(model, "_ipw_lm_call_count", current + 1)
 
     def _record_lm_end(
         pre_input: int | None,
@@ -161,21 +199,25 @@ def _instrument_openhands_llm(
     def _wrap_call(func: Any) -> Any:
         if inspect.iscoroutinefunction(func):
             async def _async_wrapped(*args: Any, **kwargs: Any) -> Any:
+                _check_turn_limit()
                 pre_input, pre_output, pre_cost = _usage_counts(model)
                 _record_event("lm_inference_start", model=str(model))
                 try:
                     return await func(*args, **kwargs)
                 finally:
+                    _mark_lm_call()
                     _record_lm_end(pre_input, pre_output, pre_cost)
 
             return _async_wrapped
 
         def _wrapped(*args: Any, **kwargs: Any) -> Any:
+            _check_turn_limit()
             pre_input, pre_output, pre_cost = _usage_counts(model)
             _record_event("lm_inference_start", model=str(model))
             try:
                 return func(*args, **kwargs)
             finally:
+                _mark_lm_call()
                 _record_lm_end(pre_input, pre_output, pre_cost)
 
         return _wrapped
@@ -651,6 +693,13 @@ class OpenHands(BaseAgent):
         "on disk."
     )
 
+    SWE_CODING_INSTRUCTIONS = (
+        "For repository repair and optimization tasks, work inside the provided "
+        "workspace. Inspect the code, make minimal tracked source changes, run "
+        "relevant checks when practical, and finish only after producing a patch "
+        "or leaving a non-empty git diff in the workspace."
+    )
+
     def __init__(
         self,
         model: Any,
@@ -658,6 +707,7 @@ class OpenHands(BaseAgent):
         mcp_tools: Optional[Dict[str, "BaseMCPServer"]] = None,
         event_recorder: Optional["EventRecorder"] = None,
         max_turns: int = DEFAULT_MAX_TURNS,
+        instructions: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the OpenHands agent.
@@ -705,7 +755,11 @@ class OpenHands(BaseAgent):
             )
 
         self.model = model
-        self._instrumented_model = _instrument_openhands_llm(model, event_recorder)
+        self._instrumented_model = _instrument_openhands_llm(
+            model,
+            event_recorder,
+            max_lm_calls=max_turns,
+        )
         self.tools = tools
         self._mcp_tools = mcp_tools or {}
         self._pending_tool: Optional[str] = None
@@ -713,6 +767,7 @@ class OpenHands(BaseAgent):
         self._num_turns: int = 0
         self._workspace: str = os.getcwd()
         self._max_turns = max_turns
+        self.instructions = instructions or self.DEFAULT_INSTRUCTIONS
 
         # Store references for use in callbacks
         self._ActionEvent = ActionEvent
@@ -743,6 +798,18 @@ class OpenHands(BaseAgent):
             "llm": self._instrumented_model,
             "condenser": condenser,
         }
+        if self.instructions:
+            try:
+                from openhands.sdk.context.agent_context import AgentContext
+
+                agent_kwargs["agent_context"] = AgentContext(
+                    system_message_suffix=self.instructions
+                )
+            except Exception:
+                logger.warning(
+                    "Unable to attach OpenHands AgentContext instructions",
+                    exc_info=True,
+                )
 
         if tools:
             agent_kwargs["tools"] = tools
@@ -879,6 +946,8 @@ class OpenHands(BaseAgent):
         # Reset per-run tracking
         self._tool_names_used = []
         self._num_turns = 0
+        object.__setattr__(self._instrumented_model, "_ipw_lm_call_count", 0)
+        turn_cap_reached = False
 
         # Create a fresh conversation for each run (previous one is closed
         # in the finally block, so we need a new one each time).
@@ -889,27 +958,57 @@ class OpenHands(BaseAgent):
 
         try:
             self.conversation.send_message(input)
-            self.conversation.run()
+            try:
+                self.conversation.run()
+            except Exception as exc:
+                if not _is_turn_limit_exception(exc):
+                    raise
+                turn_cap_reached = True
+                logger.info(
+                    "OpenHands reached max_turns=%d; returning capped response",
+                    self._max_turns,
+                )
 
-            result = get_agent_final_response(self.conversation.state.events)
+            result = (
+                None
+                if turn_cap_reached
+                else get_agent_final_response(self.conversation.state.events)
+            )
             if not result:
                 # If the SDK did not emit a finish event, ask for a final answer
                 # without lowering the iteration budget. Query/client timeouts are
                 # the operational guardrail for long-running model behavior.
-                logger.info("No FinishTool call detected, sending final-answer nudge")
-                saved_limit = self.conversation.max_iteration_per_run
-                self.conversation.max_iteration_per_run = saved_limit + 1
-                self.conversation.send_message(
-                    "Please provide your final answer now. "
-                    "Use the finish tool to submit your answer."
-                )
-                self.conversation.run()
-                self.conversation.max_iteration_per_run = saved_limit
-                result = get_agent_final_response(self.conversation.state.events)
+                if not turn_cap_reached:
+                    logger.info("No FinishTool call detected, sending final-answer nudge")
+                    saved_limit = self.conversation.max_iteration_per_run
+                    self.conversation.max_iteration_per_run = saved_limit + 1
+                    self.conversation.send_message(
+                        "Please provide your final answer now. "
+                        "Use the finish tool to submit your answer."
+                    )
+                    try:
+                        self.conversation.run()
+                    except Exception as exc:
+                        if not _is_turn_limit_exception(exc):
+                            raise
+                        turn_cap_reached = True
+                        logger.info(
+                            "OpenHands reached max_turns=%d during final-answer nudge",
+                            self._max_turns,
+                        )
+                    self.conversation.max_iteration_per_run = saved_limit
+                    result = (
+                        None
+                        if turn_cap_reached
+                        else get_agent_final_response(self.conversation.state.events)
+                    )
 
             if not result:
-                result = self._extract_text(self.current_result)
-                logger.warning("get_agent_final_response() returned empty after nudge, using callback fallback")
+                if turn_cap_reached:
+                    result = ""
+                else:
+                    result = self._extract_text(self.current_result)
+                    logger.warning("get_agent_final_response() returned empty after nudge, using callback fallback")
 
             result = self._extract_text(result)
             self.current_result = ""
@@ -938,6 +1037,11 @@ class OpenHands(BaseAgent):
                 else "missing"
             )
 
+            metadata = {"token_source": token_source}
+            if turn_cap_reached:
+                metadata["turn_cap_reached"] = True
+                metadata["max_turns"] = self._max_turns
+
             return AgentRunResult(
                 content=result,
                 tool_calls_attempted=len(self._tool_names_used),
@@ -947,7 +1051,7 @@ class OpenHands(BaseAgent):
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
                 cost_usd=cost_usd,
-                metadata={"token_source": token_source},
+                metadata=metadata,
             )
         finally:
             try:

--- a/intelligence-per-watt/src/ipw/agents/react.py
+++ b/intelligence-per-watt/src/ipw/agents/react.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
     from ipw.telemetry.events import EventRecorder
 
 
+class _IPWTurnLimitReached(RuntimeError):
+    """Raised internally when a capped run reaches its LLM-call budget."""
+
+
 @AgentRegistry.register("react")
 class React(BaseAgent):
     """React agent that uses the Agno Agent framework for tool-augmented reasoning."""
@@ -64,6 +68,7 @@ class React(BaseAgent):
         self._original_tools = tools or []
         self.instructions = instructions or self.DEFAULT_INSTRUCTIONS
         max_turns = kwargs.pop("max_turns", None)
+        self._max_turns = max(1, int(max_turns)) if max_turns is not None else None
 
         # Instrument tools if event_recorder is provided
         if event_recorder is not None and self._original_tools:
@@ -342,6 +347,10 @@ class React(BaseAgent):
 
             def _completion_with_usage(*c_args: Any, **c_kwargs: Any) -> Any:
                 nonlocal lm_started
+                if self._max_turns is not None and len(usage_calls) >= self._max_turns:
+                    raise _IPWTurnLimitReached(
+                        f"max_turns reached: {len(usage_calls)}/{self._max_turns}"
+                    )
                 lm_started = True
                 self._record_event("lm_inference_start", model=str(self.model))
                 response = original_completion(*c_args, **c_kwargs)
@@ -366,7 +375,12 @@ class React(BaseAgent):
                 litellm.completion = original_completion
 
         try:
-            result = _run_with_litellm_usage_capture()
+            turn_cap_reached = False
+            try:
+                result = _run_with_litellm_usage_capture()
+            except _IPWTurnLimitReached:
+                turn_cap_reached = True
+                result = None
             # Extract token metrics from the result if available
             end_metadata: dict[str, Any] = {"model": str(self.model)}
             input_tokens: int | None = None
@@ -443,6 +457,9 @@ class React(BaseAgent):
             metadata = {"token_source": token_source}
             if usage_metadata:
                 metadata["usage"] = usage_metadata
+            if turn_cap_reached:
+                metadata["turn_cap_reached"] = True
+                metadata["max_turns"] = self._max_turns
 
             return AgentRunResult(
                 content=content,

--- a/intelligence-per-watt/src/ipw/agents/terminus.py
+++ b/intelligence-per-watt/src/ipw/agents/terminus.py
@@ -37,6 +37,17 @@ _LITELLM_PREFIXES = (
 LOGGER = logging.getLogger(__name__)
 
 
+class _IPWTurnLimitReached(RuntimeError):
+    """Raised internally when a capped run reaches its LLM-call budget."""
+
+
+def _is_turn_limit_exception(exc: Exception) -> bool:
+    if isinstance(exc, _IPWTurnLimitReached):
+        return True
+    text = f"{type(exc).__name__}: {exc}".lower()
+    return "_ipwturnlimitreached" in text or "max_turns reached" in text
+
+
 def _cloud_litellm_model_name(model: str) -> str:
     """Return a LiteLLM provider-qualified model name for cloud calls."""
     if model.startswith(_LITELLM_PREFIXES):
@@ -127,6 +138,13 @@ class Terminus(BaseAgent):
         if max_turns is not None:
             kwargs.setdefault("max_episodes", max(1, int(max_turns)))
         self._usage_calls: list[dict[str, Any]] = []
+        self._llm_call_count = 0
+        self._max_lm_calls = max(1, int(max_turns)) if max_turns is not None else None
+        self._turn_cap_reached = False
+        self._recoverable_run_errors = (
+            ContextLengthExceededError,
+            OutputLengthExceededError,
+        )
         local_openai_endpoint = bool(kwargs.get("api_base") or kwargs.get("base_url"))
         if local_openai_endpoint:
             os.environ.setdefault("OPENAI_API_KEY", os.getenv("VLLM_API_KEY", "EMPTY"))
@@ -409,6 +427,15 @@ class Terminus(BaseAgent):
                         raise
 
             def _instrumented_call(_llm: Any, *args: Any, **call_kwargs: Any) -> str:
+                if (
+                    self._max_lm_calls is not None
+                    and self._llm_call_count >= self._max_lm_calls
+                ):
+                    self._turn_cap_reached = True
+                    raise _IPWTurnLimitReached(
+                        f"max_turns reached: {self._llm_call_count}/{self._max_lm_calls}"
+                    )
+                self._llm_call_count += 1
                 call_kwargs = {**llm_call_kwargs, **call_kwargs}
                 _trim_message_history(_llm, args, call_kwargs)
                 messages = _call_messages(args, call_kwargs)
@@ -454,6 +481,44 @@ class Terminus(BaseAgent):
         if self._container is not None:
             self.cleanup()
         self._workspace = workspace
+
+    def _is_swe_style_task(self) -> bool:
+        metadata = self._task_metadata or {}
+        dataset_name = str(metadata.get("dataset_name") or "").lower()
+        return dataset_name in {"swe-bench", "swefficiency"}
+
+    def _mark_harness_invalid(self, reason: str) -> None:
+        if self._task_metadata is None:
+            return
+        self._task_metadata["unscorable_reason"] = "harness_invalid"
+        self._task_metadata["score_metadata"] = {
+            "reason": "harness_invalid",
+            "harness_error": reason,
+        }
+
+    def _send_session_command(self, session: Any, command: str) -> None:
+        try:
+            session.send_keys([command, "Enter"], block=False)
+        except TypeError:
+            session.send_keys(command, block=False)
+
+    def _preflight_swe_workspace(self, session: Any, container: Any) -> None:
+        if not self._is_swe_style_task():
+            return
+        if self._workspace is None:
+            reason = "missing_host_workspace"
+            self._mark_harness_invalid(reason)
+            raise RuntimeError(f"Terminus SWE workspace preflight failed: {reason}")
+        result = container.exec_run(
+            ["bash", "-lc", "test -d /workspace && test -e /workspace/.git"]
+        )
+        exit_code = result.exit_code if hasattr(result, "exit_code") else result[0]
+        if exit_code != 0:
+            reason = "missing_mounted_repo_workspace"
+            self._mark_harness_invalid(reason)
+            raise RuntimeError(f"Terminus SWE workspace preflight failed: {reason}")
+        self._send_session_command(session, "cd /workspace && pwd")
+        time.sleep(0.2)
 
     def _get_docker_client(self):
         """Get or create the Docker client."""
@@ -565,6 +630,7 @@ class Terminus(BaseAgent):
                 f"Failed to start tmux session '{session_name}' in container "
                 f"'{container.name}'."
             )
+        self._preflight_swe_workspace(session, container)
         return session
 
     def _cleanup_session(self, session: Any) -> None:
@@ -625,7 +691,30 @@ class Terminus(BaseAgent):
         session = self._instrument_session_tools(self.get_session(tmux_session))
         try:
             self._usage_calls = []
-            self.agent.perform_task(input, session=session, **kwargs)
+            self._llm_call_count = 0
+            self._turn_cap_reached = False
+            recoverable_error: Exception | None = None
+            try:
+                self.agent.perform_task(input, session=session, **kwargs)
+            except _IPWTurnLimitReached:
+                pass
+            except Exception as exc:
+                if _is_turn_limit_exception(exc):
+                    pass
+                else:
+                    error_text = str(exc).lower()
+                    if not (
+                        isinstance(exc, self._recoverable_run_errors)
+                        or "contextlengthexceedederror" in error_text
+                        or "context length" in error_text
+                        or "context window" in error_text
+                        or "maximum context" in error_text
+                        or "max_tokens limit" in error_text
+                        or "hit max_tokens" in error_text
+                        or "outputlengthexceedederror" in error_text
+                    ):
+                        raise
+                    recoverable_error = exc
 
             if not session.is_session_alive():
                 raise RuntimeError(
@@ -666,6 +755,14 @@ class Terminus(BaseAgent):
                 input_tokens = None
                 output_tokens = None
                 metadata = {"token_source": "missing"}
+            if self._turn_cap_reached:
+                metadata["turn_cap_reached"] = True
+                metadata["max_turns"] = self._max_lm_calls
+            if recoverable_error is not None:
+                metadata["recoverable_agent_error"] = str(recoverable_error)
+                metadata["recoverable_agent_error_type"] = type(
+                    recoverable_error
+                ).__name__
             return AgentRunResult(
                 content=terminal_output,
                 input_tokens=input_tokens,

--- a/intelligence-per-watt/src/ipw/agents/terminus_tb.py
+++ b/intelligence-per-watt/src/ipw/agents/terminus_tb.py
@@ -28,6 +28,10 @@ if AgentRegistry.has("terminus-tb"):
     AgentRegistry._entries().pop("terminus-tb", None)
 
 
+class _IPWTurnLimitReached(RuntimeError):
+    """Raised internally when a capped run reaches its LLM-call budget."""
+
+
 @AgentRegistry.register("terminus-tb")
 class TerminusTB(BaseAgent):
     """TerminalBench agent backed by Terminus2.
@@ -73,6 +77,9 @@ class TerminusTB(BaseAgent):
         llm_call_kwargs = dict(kwargs.pop("llm_call_kwargs", None) or {})
         if max_turns is not None:
             kwargs.setdefault("max_episodes", max(1, int(max_turns)))
+        self._max_lm_calls = max(1, int(max_turns)) if max_turns is not None else None
+        self._llm_call_count = 0
+        self._turn_cap_reached = False
         self._usage_proxy: OpenAIUsageProxy | None = None
         if api_base is not None:
             os.environ.setdefault("OPENAI_API_KEY", os.getenv("VLLM_API_KEY", "EMPTY"))
@@ -135,14 +142,21 @@ class TerminusTB(BaseAgent):
 
     def _configure_llm_call_kwargs(self, llm_call_kwargs: dict[str, Any]) -> None:
         """Apply default LiteLLM call kwargs that Terminus2 does not expose."""
-        if not llm_call_kwargs:
-            return
         llm = getattr(self._terminus, "_llm", None)
         original_call = getattr(llm, "call", None)
         if not callable(original_call) or getattr(llm, "_ipw_call_kwargs_wrapped", False):
             return
 
         def _call_with_ipw_kwargs(*args: Any, **call_kwargs: Any) -> Any:
+            if (
+                self._max_lm_calls is not None
+                and self._llm_call_count >= self._max_lm_calls
+            ):
+                self._turn_cap_reached = True
+                raise _IPWTurnLimitReached(
+                    f"max_turns reached: {self._llm_call_count}/{self._max_lm_calls}"
+                )
+            self._llm_call_count += 1
             return original_call(*args, **{**llm_call_kwargs, **call_kwargs})
 
         setattr(llm, "call", _call_with_ipw_kwargs)
@@ -213,6 +227,8 @@ class TerminusTB(BaseAgent):
         usage_stats: dict[str, Any] = {}
         if self._usage_proxy is not None:
             self._usage_proxy.reset()
+        self._llm_call_count = 0
+        self._turn_cap_reached = False
 
         if not self._records_lm_calls:
             self._record_event("lm_inference_start", model=self._model_name)
@@ -225,6 +241,9 @@ class TerminusTB(BaseAgent):
                     session=session,
                     time_limit_seconds=timeout,
                 )
+            except _IPWTurnLimitReached:
+                self._turn_cap_reached = True
+                LOGGER.info("Terminus-TB reached max_turns=%s", self._max_lm_calls)
             except Exception:
                 LOGGER.exception("Terminus2 agent failed on task %s", task_id)
 
@@ -275,16 +294,21 @@ class TerminusTB(BaseAgent):
             except Exception:
                 LOGGER.debug("Cost calculation failed for %s", self._model_name, exc_info=True)
 
+        metadata = {
+            "task_id": task_id,
+            "token_source": token_source,
+            "usage_proxy": usage_stats,
+        }
+        if self._turn_cap_reached:
+            metadata["turn_cap_reached"] = True
+            metadata["max_turns"] = self._max_lm_calls
+
         return AgentRunResult(
             content=terminal_output,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=cost,
-            metadata={
-                "task_id": task_id,
-                "token_source": token_source,
-                "usage_proxy": usage_stats,
-            },
+            metadata=metadata,
         )
 
 

--- a/intelligence-per-watt/src/ipw/cli/run.py
+++ b/intelligence-per-watt/src/ipw/cli/run.py
@@ -57,6 +57,12 @@ _CODING_MCP_TOOLS = [
     "bash",
 ]
 _TERMINAL_MCP_TOOLS = ["think", "bash", "file_read", "file_write", "code_interpreter"]
+_OPENHANDS_CODING_INSTRUCTIONS = (
+    "For repository repair and optimization tasks, work inside the provided "
+    "workspace. Inspect the code, make minimal tracked source changes, run "
+    "relevant checks when practical, and finish only after producing a patch "
+    "or leaving a non-empty git diff in the workspace."
+)
 
 
 def _default_mcp_tool_spec_for_dataset(dataset_id: str) -> list[str] | None:
@@ -68,6 +74,29 @@ def _default_mcp_tool_spec_for_dataset(dataset_id: str) -> list[str] | None:
     if dataset_id in _TERMINAL_TOOL_DATASETS:
         return list(_TERMINAL_MCP_TOOLS)
     return None
+
+
+def _summarize_agent_kwargs(kwargs: dict) -> dict[str, object]:
+    """Return a JSON-safe summary of effective agent kwargs."""
+    summary: dict[str, object] = {}
+    for key, value in kwargs.items():
+        if key == "mcp_tools" and isinstance(value, dict):
+            summary[key] = sorted(str(name) for name in value)
+        elif isinstance(value, (str, int, float, bool)) or value is None:
+            summary[key] = value
+        elif isinstance(value, (list, tuple)):
+            summary[key] = [
+                item if isinstance(item, (str, int, float, bool)) or item is None else str(item)
+                for item in value
+            ]
+        elif isinstance(value, dict):
+            summary[key] = {
+                str(k): v if isinstance(v, (str, int, float, bool)) or v is None else str(v)
+                for k, v in value.items()
+            }
+        else:
+            summary[key] = str(value)
+    return summary
 
 
 def _is_cloud_model(model: str, base_url: str) -> bool:
@@ -532,6 +561,8 @@ def run_cmd(
                 extra_kwargs["mcp_tools"] = _resolve_openhands_mcp_tools(
                     default_mcp_tools
                 )
+        if agent_id == "openhands" and dataset_id in _CODING_TOOL_DATASETS:
+            extra_kwargs.setdefault("instructions", _OPENHANDS_CODING_INSTRUCTIONS)
 
     # Parse dataset kwargs
     extra_dataset_kwargs: dict = {}
@@ -662,6 +693,7 @@ def run_cmd(
         "eval_model": eval_model,
         "max_retries": max_retries,
         "require_dedicated_hardware": require_dedicated_hardware,
+        "effective_agent_kwargs": _summarize_agent_kwargs(extra_kwargs),
     }
 
     print_banner()

--- a/intelligence-per-watt/src/ipw/execution/agentic_runner.py
+++ b/intelligence-per-watt/src/ipw/execution/agentic_runner.py
@@ -9,9 +9,11 @@ import inspect
 import json
 import logging
 import math
+import os
 import re
 import signal
 import statistics
+import subprocess
 import threading
 import time
 from pathlib import Path
@@ -220,6 +222,24 @@ def _extract_patch(text: str) -> Optional[str]:
     if patch_lines:
         return "\n".join(patch_lines)
     return None
+
+
+def _workspace_git_diff(workspace: Path) -> str:
+    if not (workspace / ".git").exists():
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--binary"],
+            cwd=str(workspace),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=60,
+            env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        )
+    except Exception:
+        return ""
+    return result.stdout if result.returncode == 0 else ""
 
 
 class AgenticRunner:
@@ -1367,49 +1387,125 @@ class AgenticRunner:
         if not readings or not trace.turns:
             return trace
 
-        # Check if any turns already have energy data
-        has_turn_energy = any(
-            t.gpu_energy_joules is not None for t in trace.turns
-        )
-        if has_turn_energy:
-            return trace
+        total_wall = sum(max(0.0, t.wall_clock_s or 0.0) for t in trace.turns)
 
-        # Compute total query energy
+        # Compute total query energy.
         gpu_energies = [
             s.reading.energy_joules for s in readings
             if s.reading.energy_joules is not None
             and math.isfinite(s.reading.energy_joules)
         ]
-        total_gpu_energy = None
+        total_gpu_energy = trace.query_gpu_energy_joules
         if len(gpu_energies) >= 2:
             delta = gpu_energies[-1] - gpu_energies[0]
-            total_gpu_energy = delta if delta >= 0 else None
+            total_gpu_energy = total_gpu_energy if total_gpu_energy is not None else (
+                delta if delta >= 0 else None
+            )
+        total_gpu_power = trace.query_gpu_power_avg_watts or _compute_power_avg(
+            readings,
+            "power_watts",
+        )
 
         cpu_energies = [
             s.reading.cpu_energy_joules for s in readings
             if s.reading.cpu_energy_joules is not None
             and math.isfinite(s.reading.cpu_energy_joules)
         ]
-        total_cpu_energy = None
+        total_cpu_energy = trace.query_cpu_energy_joules
         if len(cpu_energies) >= 2:
             delta = cpu_energies[-1] - cpu_energies[0]
-            total_cpu_energy = delta if delta >= 0 else None
+            total_cpu_energy = total_cpu_energy if total_cpu_energy is not None else (
+                delta if delta >= 0 else None
+            )
+        total_cpu_power = trace.query_cpu_power_avg_watts or _compute_power_avg(
+            readings,
+            "cpu_power_watts",
+        )
 
         # Fallback: estimate from power when cumulative counters unavailable
-        total_wall = sum(t.wall_clock_s for t in trace.turns)
         if total_gpu_energy is None and total_wall > 0:
             total_gpu_energy = _estimate_energy_from_power(readings, "power_watts", total_wall)
         if total_cpu_energy is None and total_wall > 0:
             total_cpu_energy = _estimate_energy_from_power(readings, "cpu_power_watts", total_wall)
 
-        # Distribute proportionally by wall clock time
-        if total_wall > 0:
+        def _fill_missing(
+            *,
+            energy_attr: str,
+            power_attr: str,
+            total_energy: float | None,
+            total_power: float | None,
+        ) -> None:
+            missing = [
+                turn
+                for turn in trace.turns
+                if getattr(turn, energy_attr) is None
+            ]
+            if not missing:
+                for turn in trace.turns:
+                    if getattr(turn, power_attr) is None:
+                        energy = getattr(turn, energy_attr)
+                        wall = max(0.0, turn.wall_clock_s or 0.0)
+                        if energy is not None and wall > 0:
+                            setattr(turn, power_attr, energy / wall)
+                        elif total_power is not None:
+                            setattr(turn, power_attr, total_power)
+                return
+
+            known_energy = sum(
+                getattr(turn, energy_attr) or 0.0
+                for turn in trace.turns
+                if getattr(turn, energy_attr) is not None
+            )
+            remaining_energy = (
+                max(0.0, total_energy - known_energy)
+                if total_energy is not None
+                else None
+            )
+            missing_wall = sum(max(0.0, turn.wall_clock_s or 0.0) for turn in missing)
+
+            for turn in missing:
+                wall = max(0.0, turn.wall_clock_s or 0.0)
+                if remaining_energy is not None:
+                    if missing_wall > 0:
+                        energy = remaining_energy * (wall / missing_wall)
+                    else:
+                        energy = remaining_energy / len(missing)
+                elif total_power is not None and wall > 0:
+                    energy = total_power * wall
+                else:
+                    energy = None
+
+                if energy is not None:
+                    setattr(turn, energy_attr, energy)
+                    setattr(
+                        turn,
+                        power_attr,
+                        (energy / wall) if wall > 0 else total_power,
+                    )
+                elif total_power is not None and getattr(turn, power_attr) is None:
+                    setattr(turn, power_attr, total_power)
+
             for turn in trace.turns:
-                fraction = turn.wall_clock_s / total_wall
-                if total_gpu_energy is not None:
-                    turn.gpu_energy_joules = total_gpu_energy * fraction
-                if total_cpu_energy is not None:
-                    turn.cpu_energy_joules = total_cpu_energy * fraction
+                if getattr(turn, power_attr) is None:
+                    energy = getattr(turn, energy_attr)
+                    wall = max(0.0, turn.wall_clock_s or 0.0)
+                    if energy is not None and wall > 0:
+                        setattr(turn, power_attr, energy / wall)
+                    elif total_power is not None:
+                        setattr(turn, power_attr, total_power)
+
+        _fill_missing(
+            energy_attr="gpu_energy_joules",
+            power_attr="gpu_power_avg_watts",
+            total_energy=total_gpu_energy,
+            total_power=total_gpu_power,
+        )
+        _fill_missing(
+            energy_attr="cpu_energy_joules",
+            power_attr="cpu_power_avg_watts",
+            total_energy=total_cpu_energy,
+            total_power=total_cpu_power,
+        )
 
         return trace
 
@@ -1462,6 +1558,24 @@ class AgenticRunner:
             val = record.dataset_metadata.get(key)
             if val is not None:
                 meta[key] = val
+
+        dataset_id = str(getattr(self._dataset, "dataset_id", "") or "")
+        if dataset_id in {"swebench", "swefficiency"}:
+            workspace_raw = record.dataset_metadata.get("workspace_path")
+            workspace = (
+                Path(str(workspace_raw))
+                if workspace_raw
+                else query_dir / "workspace"
+            )
+            workspace_diff = _workspace_git_diff(workspace)
+            (query_dir / "workspace.diff").write_text(
+                workspace_diff,
+                encoding="utf-8",
+            )
+            meta["workspace_path"] = str(workspace)
+            meta["workspace_git_available"] = (workspace / ".git").exists()
+            meta["workspace_diff_bytes"] = len(workspace_diff.encode("utf-8"))
+
         (query_dir / "metadata.json").write_text(
             json.dumps(meta, indent=2, default=str), encoding="utf-8"
         )
@@ -1551,19 +1665,25 @@ class AgenticRunner:
 
         cost_metrics = CostMetrics(total_cost_usd=cost)
 
-        # Power metrics from trace
+        # Power metrics from trace. Prefer the query-level telemetry average
+        # when available; per-turn averages may be attribution-derived.
+        avg_gpu_power = trace.query_gpu_power_avg_watts
+        if avg_gpu_power is None:
+            avg_gpu_power = trace.avg_gpu_power_watts
+        avg_cpu_power = trace.query_cpu_power_avg_watts
+        if avg_cpu_power is None:
+            avg_cpu_power = trace.avg_cpu_power_watts
         power_metrics = PowerMetrics(
             gpu=PowerComponentMetrics(
-                per_query_watts=MetricStats(avg=trace.avg_gpu_power_watts),
+                per_query_watts=MetricStats(avg=avg_gpu_power),
             ),
             cpu=PowerComponentMetrics(
-                per_query_watts=MetricStats(avg=trace.avg_cpu_power_watts),
+                per_query_watts=MetricStats(avg=avg_cpu_power),
             ),
         )
 
         # Derived efficiency
         throughput_per_watt = None
-        avg_gpu_power = trace.avg_gpu_power_watts
         if throughput is not None and avg_gpu_power is not None and avg_gpu_power > 0:
             throughput_per_watt = throughput / avg_gpu_power
 

--- a/intelligence-per-watt/src/ipw/execution/exporters.py
+++ b/intelligence-per-watt/src/ipw/execution/exporters.py
@@ -90,12 +90,12 @@ def _compute_efficiency(
 
     ipj = (
         accuracy / total_gpu_energy
-        if (accuracy and accuracy > 0 and total_gpu_energy and total_gpu_energy > 0)
+        if (accuracy is not None and total_gpu_energy and total_gpu_energy > 0)
         else None
     )
     ipw = (
         accuracy / avg_gpu_power
-        if (accuracy and accuracy > 0 and avg_gpu_power and avg_gpu_power > 0)
+        if (accuracy is not None and avg_gpu_power and avg_gpu_power > 0)
         else None
     )
 

--- a/intelligence-per-watt/src/ipw/tests/agents/test_lightweight_harnesses.py
+++ b/intelligence-per-watt/src/ipw/tests/agents/test_lightweight_harnesses.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import subprocess
 from dataclasses import dataclass
 
 from ipw.agents.dspy_rlm import DSPyRLM
@@ -19,8 +21,10 @@ class _FakeModel:
     def __init__(self, outputs: list[str]) -> None:
         self.outputs = outputs
         self.calls = 0
+        self.prompts: list[str] = []
 
     def response(self, prompt: str) -> _Response:
+        self.prompts.append(prompt)
         output = self.outputs[min(self.calls, len(self.outputs) - 1)]
         self.calls += 1
         return _Response(output)
@@ -102,6 +106,75 @@ def test_forgecode_adds_workspace_context(tmp_path) -> None:
     assert model.calls == 1
 
 
+def test_forgecode_prompt_includes_concrete_tool_examples() -> None:
+    model = _FakeModel(["Final: done"])
+    agent = ForgeCode(
+        model=model,
+        mcp_tools={"bash": _Tool(), "file_read": _Tool(), "file_write": _Tool()},
+    )
+
+    agent.run("Fix the repo")
+
+    prompt = model.prompts[0]
+    assert "Action: bash\nAction Input:" in prompt
+    assert "Action: file_read\nAction Input:" in prompt
+    assert "Action: file_write\nAction Input:" in prompt
+    assert "Do not include chat-template markers" in prompt
+    assert "Do not spend the whole run reading files" in prompt
+    assert "make the smallest plausible edit" in prompt
+    assert "Final:\n```diff" in prompt
+
+
+def test_forgecode_rejects_excessive_read_only_inspection(tmp_path) -> None:
+    subprocess.run(
+        ["git", "init"],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    model = _FakeModel(["Action: bash\nAction Input: grep -R foo ."] * 5)
+    tool = _RecordingTool()
+    agent = ForgeCode(model=model, mcp_tools={"bash": tool}, max_turns=5)
+    agent.set_workspace(str(tmp_path))
+
+    result = agent.run("Fix the repo")
+
+    assert len(tool.prompts) == 3
+    assert result.tool_calls_attempted == 5
+    assert result.tool_calls_succeeded == 3
+    assert any("Read-only inspection budget exhausted" in prompt for prompt in model.prompts)
+
+
+def test_forgecode_turn_limit_nudges_final_diff(tmp_path) -> None:
+    subprocess.run(
+        ["git", "init"],
+        cwd=tmp_path,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+    model = _FakeModel(
+        [
+            "Action: bash\nAction Input: grep -R foo .",
+            "Action: bash\nAction Input: grep -R bar .",
+            "Action: bash\nAction Input: grep -R baz .",
+            "Action: bash\nAction Input: grep -R qux .",
+            "Final:\n```diff\ndiff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n-a\n+b\n```",
+        ]
+    )
+    tool = _RecordingTool()
+    agent = ForgeCode(model=model, mcp_tools={"bash": tool}, max_turns=4)
+    agent.set_workspace(str(tmp_path))
+
+    result = agent.run("Fix the repo")
+
+    assert len(tool.prompts) == 3
+    assert model.calls == 5
+    assert "Tool budget exhausted" in model.prompts[-1]
+    assert "diff --git a/a.py b/a.py" in result.content
+
+
 def test_local_openai_context_trimming_preserves_task(monkeypatch) -> None:
     monkeypatch.setenv("IPW_OPENAI_COMPAT_CONTEXT_WINDOW", "2048")
     agent = DSPyRLM(
@@ -123,3 +196,39 @@ def test_local_openai_context_trimming_preserves_task(monkeypatch) -> None:
     assert trimmed[1]["content"] == "original task"
     assert len(trimmed) < len(messages)
     assert any("omitted" in message["content"] for message in trimmed)
+
+
+def test_local_openai_context_retry_uses_reported_vllm_budget(monkeypatch) -> None:
+    agent = DSPyRLM(
+        model={"model": "m", "base_url": "http://127.0.0.1:1/v1", "api_key": "EMPTY"},
+        max_output_tokens=1000,
+    )
+    payloads: list[dict[str, object]] = []
+
+    class _Response:
+        def __init__(self, status_code: int, text: str = "") -> None:
+            self.status_code = status_code
+            self.text = text
+
+    def _post(*_args, **kwargs):
+        payloads.append(json.loads(kwargs["data"]))
+        if len(payloads) == 1:
+            return _Response(
+                400,
+                "This model's maximum context length is 4096 tokens. "
+                "However, you requested 4097 tokens (3900 in the messages, "
+                "197 in the completion).",
+            )
+        return _Response(200)
+
+    monkeypatch.setattr("ipw.agents.openai_compat.requests.post", _post)
+
+    response = agent._post_openai_chat(
+        base_url="http://127.0.0.1:1/v1",
+        headers={},
+        payload={"model": "m", "messages": [], "max_tokens": 197},
+    )
+
+    assert response.status_code == 200
+    assert payloads[0]["max_tokens"] == 197
+    assert payloads[1]["max_tokens"] == 195

--- a/intelligence-per-watt/src/ipw/tests/agents/test_openhands_integration.py
+++ b/intelligence-per-watt/src/ipw/tests/agents/test_openhands_integration.py
@@ -31,6 +31,7 @@ def _clean_openhands_registration():
 def _mock_openhands():
     """Patch openhands SDK imports used by the OpenHands agent."""
     mock_agent_cls = MagicMock()
+    mock_agent_context_cls = MagicMock()
     mock_conversation_cls = MagicMock()
     mock_condenser_cls = MagicMock()
     mock_event = MagicMock()
@@ -59,11 +60,16 @@ def _mock_openhands():
         "openhands.sdk.conversation.response_utils": MagicMock(
             get_agent_final_response=MagicMock(return_value="The final answer"),
         ),
+        "openhands.sdk.context": MagicMock(),
+        "openhands.sdk.context.agent_context": MagicMock(
+            AgentContext=mock_agent_context_cls,
+        ),
     }
 
     with patch.dict("sys.modules", modules):
         yield {
             "Agent": mock_agent_cls,
+            "AgentContext": mock_agent_context_cls,
             "LocalConversation": mock_conversation_cls,
             "Condenser": mock_condenser_cls,
             "ActionEvent": mock_action_event,
@@ -86,6 +92,21 @@ class TestOpenHandsIntegration:
         # class reference and the kwargs.
         assert agent._Agent is _mock_openhands["Agent"]
         _mock_openhands["Agent"].assert_not_called()
+
+    def test_passes_instructions_to_agent_context(self, _mock_openhands: dict) -> None:
+        from ipw.agents.openhands import OpenHands
+
+        model = MagicMock()
+        agent = OpenHands(model=model, instructions="Edit the repo and submit a patch.")
+
+        assert agent.instructions == "Edit the repo and submit a patch."
+        _mock_openhands["AgentContext"].assert_called_once_with(
+            system_message_suffix="Edit the repo and submit a patch."
+        )
+        _mock_openhands["Agent"].assert_not_called()
+        assert agent._agent_kwargs["agent_context"] is (
+            _mock_openhands["AgentContext"].return_value
+        )
 
     def test_run_returns_agent_run_result(self, _mock_openhands: dict) -> None:
         from ipw.agents.openhands import OpenHands

--- a/intelligence-per-watt/src/ipw/tests/agents/test_vllm_context_budget.py
+++ b/intelligence-per-watt/src/ipw/tests/agents/test_vllm_context_budget.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import httpx
+
+from ipw.agents.mcp.vllm_server import VLLMMCPServer
+
+
+def test_vllm_mcp_retry_uses_reported_context_budget(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+
+    class _Client:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def post(self, url: str, *, headers: dict[str, str], json: dict[str, object]):
+            payloads.append(dict(json))
+            request = httpx.Request("POST", url)
+            if len(payloads) == 1:
+                return httpx.Response(
+                    400,
+                    text=(
+                        "This model's maximum context length is 4096 tokens. "
+                        "However, you requested 4097 tokens (3900 in the messages, "
+                        "197 in the completion). max_tokens is too large."
+                    ),
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {"message": {"content": "ok"}, "finish_reason": "stop"}
+                    ],
+                    "usage": {
+                        "prompt_tokens": 3900,
+                        "completion_tokens": 10,
+                        "total_tokens": 3910,
+                    },
+                },
+                request=request,
+            )
+
+    monkeypatch.setattr("ipw.agents.mcp.vllm_server.httpx.Client", _Client)
+
+    server = VLLMMCPServer(
+        model_name="test-model",
+        vllm_url="http://127.0.0.1:1",
+        max_tokens=197,
+    )
+
+    result = server.execute("hello")
+
+    assert result.content == "ok"
+    assert payloads[0]["max_tokens"] == 197
+    assert payloads[1]["max_tokens"] == 195
+    assert result.metadata["max_tokens_capped"] is True

--- a/intelligence-per-watt/src/ipw/tests/execution/test_agentic_runner.py
+++ b/intelligence-per-watt/src/ipw/tests/execution/test_agentic_runner.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,7 +18,7 @@ from ipw.execution.agentic_runner import (
     _compute_power_avg,
 )
 from ipw.execution.telemetry_session import TelemetrySample
-from ipw.execution.trace import QueryTrace
+from ipw.execution.trace import QueryTrace, TurnTrace
 from ipw.telemetry.events import EventRecorder, EventType
 
 
@@ -710,6 +712,63 @@ class TestAgenticRunner:
         assert metrics.judge_gpu_joules == pytest.approx(3.0)
         assert metrics.total_task_gpu_joules == pytest.approx(15.0)
 
+    def test_correlate_energy_fills_partially_missing_turn_energy(self) -> None:
+        """Partial per-turn energy attribution is completed without double-counting."""
+        runner = self._make_runner()
+        trace = QueryTrace(
+            query_id="q1",
+            workload_type="agentic",
+            query_text="Q1",
+            response_text="A1",
+            total_wall_clock_s=4.0,
+            completed=True,
+            turns=[
+                TurnTrace(
+                    turn_index=0,
+                    wall_clock_s=1.0,
+                    gpu_energy_joules=2.0,
+                    cpu_energy_joules=1.0,
+                ),
+                TurnTrace(turn_index=1, wall_clock_s=2.0),
+                TurnTrace(turn_index=2, wall_clock_s=1.0),
+            ],
+            query_gpu_energy_joules=10.0,
+            query_cpu_energy_joules=5.0,
+            query_gpu_power_avg_watts=2.5,
+            query_cpu_power_avg_watts=1.25,
+        )
+        readings = [
+            TelemetrySample(
+                timestamp=1000.0,
+                reading=TelemetryReading(
+                    energy_joules=100.0,
+                    power_watts=2.0,
+                    cpu_energy_joules=50.0,
+                    cpu_power_watts=1.0,
+                ),
+            ),
+            TelemetrySample(
+                timestamp=1004.0,
+                reading=TelemetryReading(
+                    energy_joules=110.0,
+                    power_watts=3.0,
+                    cpu_energy_joules=55.0,
+                    cpu_power_watts=1.5,
+                ),
+            ),
+        ]
+
+        updated = runner._correlate_energy(trace, readings)
+
+        assert [t.gpu_energy_joules for t in updated.turns] == pytest.approx(
+            [2.0, 16.0 / 3.0, 8.0 / 3.0]
+        )
+        assert [t.cpu_energy_joules for t in updated.turns] == pytest.approx(
+            [1.0, 8.0 / 3.0, 4.0 / 3.0]
+        )
+        assert all(t.gpu_power_avg_watts is not None for t in updated.turns)
+        assert all(t.cpu_power_avg_watts is not None for t in updated.turns)
+
     def test_cost_computation_wired(self) -> None:
         """Cost is computed from pricing tables when trace has no cost but has tokens."""
         agent = MagicMock()
@@ -811,6 +870,81 @@ class TestAgenticRunner:
         assert meta["is_resolved"] is True
         assert meta["test_results"] == {"passed": 5, "failed": 0}
 
+    def test_swe_workspace_diff_persisted_in_artifacts(self, tmp_path) -> None:
+        class EditingAgent(BaseAgent):
+            def __init__(self) -> None:
+                super().__init__()
+                self.workspace = None
+
+            def set_workspace(self, workspace_path: str) -> None:
+                self.workspace = Path(workspace_path)
+
+            def run(self, input: str, **kwargs) -> AgentRunResult:
+                assert self.workspace is not None
+                (self.workspace / "tracked.py").write_text("changed\n", encoding="utf-8")
+                return AgentRunResult(content="done")
+
+        class SweDataset:
+            dataset_id = "swebench"
+
+            def __init__(self) -> None:
+                self.records = [
+                    DatasetRecord(
+                        problem="Q1",
+                        answer="",
+                        subject="s",
+                        dataset_metadata={
+                            "dataset_name": "SWE-bench",
+                            "instance_id": "inst_001",
+                        },
+                    )
+                ]
+
+            def __iter__(self):
+                return iter(self.records)
+
+            def size(self) -> int:
+                return len(self.records)
+
+            def create_task_env(self, record):
+                return None
+
+            def prepare_workspace(self, record, workspace) -> None:
+                workspace.mkdir(parents=True, exist_ok=True)
+                subprocess.run(["git", "init"], cwd=workspace, check=True)
+                subprocess.run(
+                    ["git", "config", "user.email", "test@example.com"],
+                    cwd=workspace,
+                    check=True,
+                )
+                subprocess.run(
+                    ["git", "config", "user.name", "Test User"],
+                    cwd=workspace,
+                    check=True,
+                )
+                (workspace / "tracked.py").write_text("old\n", encoding="utf-8")
+                subprocess.run(["git", "add", "tracked.py"], cwd=workspace, check=True)
+                subprocess.run(
+                    ["git", "commit", "-m", "initial"],
+                    cwd=workspace,
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                record.dataset_metadata["workspace_path"] = str(workspace)
+
+        runner = AgenticRunner(
+            agent=EditingAgent(),
+            dataset=SweDataset(),
+            config={"model": "test-model"},
+            run_dir=tmp_path,
+        )
+        asyncio.run(runner.run())
+
+        workspace_diff = tmp_path / "artifacts" / "q0000_inst_001" / "workspace.diff"
+        assert workspace_diff.exists()
+        assert "-old" in workspace_diff.read_text(encoding="utf-8")
+        assert "+changed" in workspace_diff.read_text(encoding="utf-8")
 
     def test_local_model_cost_is_zero(self) -> None:
         """Cost = 0.0 when client_base_url is localhost (local inference)."""


### PR DESCRIPTION
## Summary

Fixes eval trace validity issues found while running the benchmark matrix:

- retry vLLM context-limit failures with the exact reported token budget
- preserve measured query-level power while filling missing per-turn telemetry
- improve patch/workspace artifact capture for coding harnesses
- add explicit capped-run and invalid-run metadata across harnesses

## Validation

Focused PR tests:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest \
  src/ipw/tests/agents/test_lightweight_harnesses.py \
  src/ipw/tests/agents/test_vllm_context_budget.py \
  src/ipw/tests/agents/test_openhands_integration.py \
  src/ipw/tests/execution/test_agentic_runner.py
```

Result: `79 passed`.

Full suite:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest
```

Result: `1039 passed, 56 skipped, 1 deselected, 1 failed`. The failure is
`test_apple_telemetry.py::test_ioreg_gpu_info`, caused by strict UTF-8 decoding
of local macOS `ioreg` output.
